### PR TITLE
Add universal artist search and expandable graph

### DIFF
--- a/my-app/src/App.tsx
+++ b/my-app/src/App.tsx
@@ -1,50 +1,100 @@
-import { useEffect, useState } from 'react'
-import ReactFlow, { Background, Controls, MiniMap } from 'reactflow'
-import type { Node, Edge } from 'reactflow'
+import { useCallback, useRef, useState } from 'react'
+import ReactFlow, { Background, Controls, MiniMap, type Node, type Edge } from 'reactflow'
 import 'reactflow/dist/style.css'
+import SearchBar from './components/SearchBar'
+import GraphNode from './components/GraphNode'
+import { fetchJson } from './utils/dataFetcher'
 
-const DAVE_MBID = '4d5f891d-9bce-45ae-ad86-912dd27252fa'
+const nodeTypes = { graphNode: GraphNode }
 
 function App() {
   const [nodes, setNodes] = useState<Node[]>([])
   const [edges, setEdges] = useState<Edge[]>([])
+  const loaded = useRef(new Set<string>())
 
-  useEffect(() => {
-    async function load() {
+  const addNode = useCallback((id: string, label: string, type: 'artist' | 'band', tooltip?: string) => {
+    setNodes((ns) => {
+      if (ns.find((n) => n.id === id)) return ns
+      const position = { x: Math.random() * 800, y: Math.random() * 600 }
+      return [...ns, { id, data: { label, type, tooltip }, position, type: 'graphNode' }]
+    })
+  }, [])
+
+  const addEdge = useCallback((source: string, target: string) => {
+    setEdges((es) => {
+      if (es.find((e) => e.source === source && e.target === target)) return es
+      return [...es, { id: `e-${source}-${target}`, source, target }]
+    })
+  }, [])
+
+  interface Relation {
+    type: string
+    artist?: { id: string; name: string }
+    attributes?: string[]
+    begin?: string
+    end?: string
+  }
+
+  const parseTooltip = useCallback((rel: Relation) => {
+    const role = (rel.attributes || []).join(', ')
+    const years = rel.begin || rel.end ? `${rel.begin || ''} - ${rel.end || ''}` : ''
+    return [role, years].filter(Boolean).join(' ')
+  }, [])
+
+  const loadArtist = useCallback(
+    async (mbid: string) => {
+      if (loaded.current.has(mbid)) return
+      loaded.current.add(mbid)
       try {
-        const res = await fetch(`https://musicbrainz.org/ws/2/artist/${DAVE_MBID}?inc=artist-rels&fmt=json`)
-        const data = await res.json()
-        const newNodes: Node[] = [
-          { id: DAVE_MBID, data: { label: data.name }, position: { x: 0, y: 0 }, type: 'default' }
-        ]
-        const newEdges: Edge[] = []
-        let y = 100
+        interface ArtistData {
+          id: string
+          name: string
+          type: string
+          'life-span'?: { begin?: string; end?: string }
+          relations?: Relation[]
+        }
+
+        const data = await fetchJson<ArtistData>(
+          `https://musicbrainz.org/ws/2/artist/${mbid}?inc=artist-rels&fmt=json`
+        )
+        const type = data.type === 'Group' ? 'band' : 'artist'
+        const life = data['life-span']
+        const years = life && (life.begin || life.end) ? `${life.begin || ''} - ${life.end || ''}` : ''
+        addNode(data.id, data.name, type, years)
         for (const rel of data.relations || []) {
           if (rel.type === 'member of band' && rel.artist) {
-            const band = rel.artist
-            if (!newNodes.find(n => n.id === band.id)) {
-              newNodes.push({ id: band.id, data: { label: band.name }, position: { x: 200, y }, type: 'default' })
-              y += 100
-            }
-            newEdges.push({ id: `e-${DAVE_MBID}-${band.id}`, source: DAVE_MBID, target: band.id })
+            addNode(rel.artist.id, rel.artist.name, 'band', parseTooltip(rel))
+            addEdge(data.id, rel.artist.id)
+          }
+          if (rel.type === 'has member' && rel.artist) {
+            addNode(rel.artist.id, rel.artist.name, 'artist', parseTooltip(rel))
+            addEdge(data.id, rel.artist.id)
           }
         }
-        setNodes(newNodes)
-        setEdges(newEdges)
       } catch (err) {
         console.error(err)
       }
-    }
-    load()
-  }, [])
+    },
+    [addEdge, addNode, parseTooltip]
+  )
+
+  const handleNodeClick = useCallback<import('reactflow').NodeMouseHandler>(
+    (_event, node) => {
+      loadArtist(node.id)
+    },
+    [loadArtist]
+  )
 
   return (
-    <div style={{ width: '100%', height: '100vh' }}>
-      <ReactFlow nodes={nodes} edges={edges} fitView>
-        <MiniMap />
-        <Controls />
-        <Background />
-      </ReactFlow>
+    <div className="w-screen h-screen">
+      <SearchBar onSelect={(a) => loadArtist(a.id)} />
+      <div style={{ width: '100%', height: 'calc(100% - 50px)' }}>
+        <ReactFlow nodes={nodes} edges={edges} onNodeClick={handleNodeClick} nodeTypes={nodeTypes} fitView>
+          <MiniMap />
+          <Controls />
+          <Background />
+        </ReactFlow>
+      </div>
     </div>
   )
 }

--- a/my-app/src/components/GraphNode.tsx
+++ b/my-app/src/components/GraphNode.tsx
@@ -1,0 +1,21 @@
+import type { NodeProps } from 'reactflow'
+
+interface Data {
+  label: string
+  type: 'artist' | 'band'
+  tooltip?: string
+}
+
+export default function GraphNode({ data }: NodeProps<Data>) {
+  return (
+    <div
+      className={
+        'px-2 py-1 rounded shadow text-xs ' +
+        (data.type === 'band' ? 'bg-blue-200' : 'bg-green-200')
+      }
+      title={data.tooltip}
+    >
+      {data.label}
+    </div>
+  )
+}

--- a/my-app/src/components/SearchBar.tsx
+++ b/my-app/src/components/SearchBar.tsx
@@ -1,0 +1,61 @@
+import { useEffect, useState } from 'react'
+import { fetchJson } from '../utils/dataFetcher'
+
+interface Artist {
+  id: string
+  name: string
+  disambiguation?: string
+}
+
+export default function SearchBar({ onSelect }: { onSelect: (artist: Artist) => void }) {
+  const [query, setQuery] = useState('')
+  const [results, setResults] = useState<Artist[]>([])
+
+  useEffect(() => {
+    if (!query) {
+      setResults([])
+      return
+    }
+    const handler = setTimeout(async () => {
+      try {
+        const data = await fetchJson<{ artists: Artist[] }>(
+          `https://musicbrainz.org/ws/2/artist/?query=${encodeURIComponent(query)}&fmt=json`
+        )
+        setResults(data.artists.slice(0, 5))
+      } catch (err) {
+        console.error(err)
+        setResults([])
+      }
+    }, 500)
+    return () => clearTimeout(handler)
+  }, [query])
+
+  return (
+    <div className="p-2 bg-gray-100">
+      <input
+        className="border p-1 w-64"
+        placeholder="Search artist"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+      />
+      {results.length > 0 && (
+        <ul className="bg-white border mt-1 max-h-40 overflow-auto">
+          {results.map((a) => (
+            <li
+              key={a.id}
+              className="p-1 hover:bg-blue-100 cursor-pointer"
+              onClick={() => {
+                onSelect(a)
+                setQuery('')
+                setResults([])
+              }}
+            >
+              {a.name}
+              {a.disambiguation ? ` (${a.disambiguation})` : ''}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/my-app/src/utils/dataFetcher.ts
+++ b/my-app/src/utils/dataFetcher.ts
@@ -1,0 +1,25 @@
+let lastFetch = 0
+const cache = new Map<string, unknown>()
+
+export async function fetchJson<T = unknown>(url: string): Promise<T> {
+  if (cache.has(url)) {
+    return cache.get(url) as T
+  }
+  const now = Date.now()
+  const wait = Math.max(0, 1000 - (now - lastFetch))
+  if (wait) {
+    await new Promise((res) => setTimeout(res, wait))
+  }
+  lastFetch = Date.now()
+  const res = await fetch(url, {
+    headers: {
+      'User-Agent': 'MusicGenealogy/1.0 ( example@example.com )'
+    }
+  })
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status}`)
+  }
+  const data = (await res.json()) as T
+  cache.set(url, data)
+  return data
+}


### PR DESCRIPTION
## Summary
- add SearchBar component for artist lookup
- add GraphNode component with artist and band types
- implement rate-limited fetch helper
- load artists and bands dynamically on selection or node click

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68572ab854a08332a6766be6b3822db5