### PR TITLE
Improve graph exploration UX

### DIFF
--- a/src/components/GraphNode.tsx
+++ b/src/components/GraphNode.tsx
@@ -11,7 +11,8 @@ export default function GraphNode({ data }: NodeProps<Data>) {
     <div
       className={
         'px-2 py-1 rounded shadow text-xs ' +
-        (data.type === 'band' ? 'bg-blue-200' : 'bg-green-200')
+        (data.type === 'band' ? 'bg-blue-200' : 'bg-green-200') +
+        ' cursor-pointer'
       }
       title={data.tooltip}
     >


### PR DESCRIPTION
## Summary
- reset graph on new artist search
- label edges and position nodes relative to their parent
- center the view when a new search loads
- show node details in a side panel
- add pointer cursor style for graph nodes

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685735ad8b588332b969fe0510eeed3b