### PR TITLE
Add visual styling and labeled edges

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,13 +6,16 @@ import ReactFlow, {
   type Node,
   type Edge,
   useReactFlow,
+  MarkerType,
 } from 'reactflow'
 import 'reactflow/dist/style.css'
 import SearchBar from './components/SearchBar'
 import GraphNode from './components/GraphNode'
+import CustomEdge from './components/CustomEdge'
 import { fetchJson } from './utils/dataFetcher'
 
 const nodeTypes = { graphNode: GraphNode }
+const edgeTypes = { custom: CustomEdge }
 
 function App() {
   const [nodes, setNodes] = useState<Node[]>([])
@@ -62,7 +65,14 @@ function App() {
         if (es.find((e) => e.source === source && e.target === target)) return es
         return [
           ...es,
-          { id: `e-${source}-${target}`, source, target, label, type: 'smoothstep' },
+          {
+            id: `e-${source}-${target}`,
+            source,
+            target,
+            label,
+            type: label ? 'custom' : 'smoothstep',
+            markerEnd: { type: MarkerType.ArrowClosed, color: '#555' },
+          },
         ]
       })
     },
@@ -161,6 +171,7 @@ function App() {
           onNodeClick={handleNodeClick}
           onNodeDoubleClick={handleNodeDoubleClick}
           nodeTypes={nodeTypes}
+          edgeTypes={edgeTypes}
         >
           <MiniMap />
           <Controls />

--- a/src/components/CustomEdge.tsx
+++ b/src/components/CustomEdge.tsx
@@ -1,0 +1,44 @@
+import { BaseEdge, EdgeLabelRenderer, type EdgeProps, getSmoothStepPath } from 'reactflow'
+
+export default function CustomEdge(props: EdgeProps) {
+  const {
+    sourceX,
+    sourceY,
+    targetX,
+    targetY,
+    sourcePosition,
+    targetPosition,
+    markerEnd,
+    style,
+    label,
+  } = props
+
+  const [edgePath, labelX, labelY] = getSmoothStepPath({
+    sourceX,
+    sourceY,
+    targetX,
+    targetY,
+    sourcePosition,
+    targetPosition,
+  })
+
+  return (
+    <>
+      <BaseEdge path={edgePath} style={style} markerEnd={markerEnd} />
+      {label && (
+        <EdgeLabelRenderer>
+          <div
+            style={{
+              position: 'absolute',
+              transform: `translate(-50%, -50%) translate(${labelX}px,${labelY}px)`,
+              pointerEvents: 'none',
+            }}
+            className="bg-white border text-[10px] rounded px-1"
+          >
+            {label}
+          </div>
+        </EdgeLabelRenderer>
+      )}
+    </>
+  )
+}

--- a/src/components/GraphNode.tsx
+++ b/src/components/GraphNode.tsx
@@ -1,4 +1,4 @@
-import type { NodeProps } from 'reactflow'
+import { Handle, Position, type NodeProps } from 'reactflow'
 
 interface Data {
   label: string
@@ -10,13 +10,14 @@ export default function GraphNode({ data }: NodeProps<Data>) {
   return (
     <div
       className={
-        'px-2 py-1 rounded shadow text-xs ' +
-        (data.type === 'band' ? 'bg-blue-200' : 'bg-green-200') +
-        ' cursor-pointer'
+        'px-3 py-2 rounded border shadow text-xs text-white ' +
+        (data.type === 'artist' ? 'bg-blue-600' : 'bg-red-600')
       }
       title={data.tooltip}
     >
+      <Handle type="target" position={Position.Top} />
       {data.label}
+      <Handle type="source" position={Position.Bottom} />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- color artist and band nodes differently
- show arrow markers and labels on edges
- add custom edge component for labels

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68573ce9339c8332b29fdf93eea46676