### PR TITLE
Switch to ERD-style panels

### DIFF
--- a/src/components/GraphNode.tsx
+++ b/src/components/GraphNode.tsx
@@ -1,23 +1,53 @@
 import { Handle, Position, type NodeProps } from 'reactflow'
 
+export interface RelationDisplay {
+  id: string
+  name: string
+  type: 'artist' | 'band'
+  role?: string
+  years?: string
+}
+
 interface Data {
+  id: string
   label: string
   type: 'artist' | 'band'
   tooltip?: string
+  relations?: RelationDisplay[]
+  onRelationClick?: (parent: string, rel: RelationDisplay) => void
 }
 
-export default function GraphNode({ data }: NodeProps<Data>) {
+function roleEmoji(role?: string): string {
+  if (!role) return ''
+  const r = role.toLowerCase()
+  if (r.includes('guitar')) return '🎸'
+  if (r.includes('drum')) return '🥁'
+  if (r.includes('vocal')) return '🎤'
+  return ''
+}
+
+export default function GraphNode({ id, data }: NodeProps<Data>) {
   return (
     <div
-      className={
-        'px-3 py-2 rounded border shadow text-xs text-white ' +
-        (data.type === 'artist' ? 'bg-blue-600' : 'bg-red-600')
-      }
+      className="bg-white border rounded shadow text-xs text-black w-64 animate-fade-in"
       title={data.tooltip}
     >
-      <Handle type="target" position={Position.Top} />
-      {data.label}
-      <Handle type="source" position={Position.Bottom} />
+      <Handle type="target" position={Position.Left} />
+      <div className="font-bold bg-gray-100 px-2 py-1 text-sm">{data.label}</div>
+      <div className="max-h-40 overflow-auto">
+        {data.relations?.map((rel) => (
+          <div
+            key={rel.id}
+            className="flex items-center gap-1 px-2 py-1 hover:bg-blue-100 cursor-pointer"
+            onClick={() => data.onRelationClick?.(id, rel)}
+          >
+            <span>{roleEmoji(rel.role)}</span>
+            <span className="flex-1 truncate">{rel.name}</span>
+            {rel.years && <span className="text-gray-500">{rel.years}</span>}
+          </div>
+        ))}
+      </div>
+      <Handle type="source" position={Position.Right} />
     </div>
   )
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,7 +5,17 @@ export default {
     "./src/**/*.{js,ts,jsx,tsx}"
   ],
   theme: {
-    extend: {},
+    extend: {
+      keyframes: {
+        fadeIn: {
+          '0%': { opacity: '0', transform: 'translateY(0.25rem)' },
+          '100%': { opacity: '1', transform: 'translateY(0)' },
+        },
+      },
+      animation: {
+        'fade-in': 'fadeIn 0.3s ease-out forwards',
+      },
+    },
   },
   plugins: [],
 }


### PR DESCRIPTION
## Summary
- add fade-in animation for nodes
- swap force graph nodes for ERD-like table panels
- use relation rows that spawn new panels when clicked
- map common roles to emoji icons

## Testing
- `npm run lint`
- `./node_modules/.bin/tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_685746fdbdb88332accd57d8c6d328b7